### PR TITLE
Fix `shmem_team_split_strided`'s `start` argument wording.

### DIFF
--- a/content/shmem_team_split_strided.tex
+++ b/content/shmem_team_split_strided.tex
@@ -13,7 +13,7 @@ int @\FuncDecl{shmem\_team\_split\_strided}@(shmem_team_t parent_team, int start
 \begin{apiarguments}
 \apiargument{IN}{parent\_team}{An \openshmem team.}
 
-\apiargument{IN}{start}{The first \acs{PE} number of the subset of \acp{PE} from the parent team that will form the new team. If the stride is less than zero, the first \acs{PE} number is the highest; if greater than zero, it is the lowest; if the stride is zero, it is the starting \acs{PE}.}
+\apiargument{IN}{start}{The first \acs{PE} number of the subset of \acp{PE} from the parent team that will form the new team. If the stride is less than zero, the first \acs{PE} number is the highest \acs{PE} of the parent team; if it is  greater than zero, it is the lowest; if the stride is zero, it is the starting \acs{PE}.}
 
 \apiargument{IN}{stride}{The stride between team \ac{PE}
 numbers in the parent team that comprise the subset of \acp{PE} that will form

--- a/content/shmem_team_split_strided.tex
+++ b/content/shmem_team_split_strided.tex
@@ -13,8 +13,7 @@ int @\FuncDecl{shmem\_team\_split\_strided}@(shmem_team_t parent_team, int start
 \begin{apiarguments}
 \apiargument{IN}{parent\_team}{An \openshmem team.}
 
-\apiargument{IN}{start}{The lowest \ac{PE} number of the subset of \acp{PE} from
-the parent team that will form the new team.}
+\apiargument{IN}{start}{The first \acs{PE} number of the subset of \acp{PE} from the parent team that will form the new team. If the stride is less than zero, the first \acs{PE} number is the highest; if greater than zero, it is the lowest; if the stride is zero, it is the starting \acs{PE}.}
 
 \apiargument{IN}{stride}{The stride between team \ac{PE}
 numbers in the parent team that comprise the subset of \acp{PE} that will form


### PR DESCRIPTION
# Summary of changes

This PR fixes the wording of `shmem_team_split_strided`'s `start` argument for non-positive value. 

I think the entry in the backmatter still covers this but let me know if we need to tweak it as well:
https://github.com/davidozog/openshmem-specification/blob/a392d409d6dd3d94f6685eaf9fe5941bb0e40c8d/content/backmatter.tex#L706-L708

## Relevant PRs are:

* This PR follows up on the discussion in this PR: https://github.com/openshmem-org/specification/pull/519
* And the draft card is here (I can't convert it to an issue): https://github.com/orgs/openshmem-org/projects/5?query=sort%3Aupdated-desc+is%3Aopen&pane=issue&itemId=76216671

# Proposal Checklist
- [ ] Link to issue(s)
- [ ] Changelog entry
- [ ] Reviewed for changes to front matter
- [ ] Reviewed for changes to back matter
