### PR TITLE
teams: split does not permit parent PE wrap-around

### DIFF
--- a/content/shmem_team_split_strided.tex
+++ b/content/shmem_team_split_strided.tex
@@ -13,7 +13,7 @@ int @\FuncDecl{shmem\_team\_split\_strided}@(shmem_team_t parent_team, int start
 \begin{apiarguments}
 \apiargument{IN}{parent\_team}{An \openshmem team.}
 
-\apiargument{IN}{start}{The lowest \ac{PE} number of the subset of \acp{PE} from
+\apiargument{IN}{start}{The first \ac{PE} number of the subset of \acp{PE} from
 the parent team that will form the new team.}
 
 \apiargument{IN}{stride}{The stride between team \ac{PE}
@@ -59,6 +59,17 @@ When $stride$ is less than zero, PEs in the new team are in \textit{reverse}
 relative order with respect to the parent team.
 If a $stride$ value equal to 0 is passed to \FUNC{shmem\_team\_split\_strided},
 then the $size$ argument passed must be 1, or the behavior is undefined.
+A newly created team must only include \acp{PE} whose subsequent parent \ac{PE}
+values are either all increasing (for positive $stride$) or all decreasing
+(for negative $stride$).
+That is, \textit{wrap-around} with respect to the parent team's \ac{PE} values
+is not permitted.
+For example, the list of \acp{PE} in the parent team should not start at a high
+number and then continue to include \acp{PE} in the lower end of the parent
+team's \ac{PE} range.
+If the triplet provided to \FUNC{shmem\_team\_split\_strided} implies such a
+wrap-around sequence, the input is considered invalid and the behavior is
+undefined.
 
 This routine must be called by all \acp{PE} in the parent team.
 All \acp{PE} must provide the same values for the \ac{PE} triplet.

--- a/content/shmem_team_split_strided.tex
+++ b/content/shmem_team_split_strided.tex
@@ -13,7 +13,7 @@ int @\FuncDecl{shmem\_team\_split\_strided}@(shmem_team_t parent_team, int start
 \begin{apiarguments}
 \apiargument{IN}{parent\_team}{An \openshmem team.}
 
-\apiargument{IN}{start}{The first \ac{PE} number of the subset of \acp{PE} from
+\apiargument{IN}{start}{The lowest \ac{PE} number of the subset of \acp{PE} from
 the parent team that will form the new team.}
 
 \apiargument{IN}{stride}{The stride between team \ac{PE}

--- a/content/shmem_team_split_strided.tex
+++ b/content/shmem_team_split_strided.tex
@@ -59,6 +59,17 @@ When $stride$ is less than zero, PEs in the new team are in \textit{reverse}
 relative order with respect to the parent team.
 If a $stride$ value equal to 0 is passed to \FUNC{shmem\_team\_split\_strided},
 then the $size$ argument passed must be 1, or the behavior is undefined.
+A newly created team must only include \acp{PE} whose subsequent parent \ac{PE}
+values are either all increasing (for positive $stride$) or all decreasing
+(for negative $stride$).
+That is, \textit{wrap-around} with respect to the parent team's \ac{PE} values
+is not permitted.
+For example, the list of \acp{PE} in the parent team should not start at a high
+number and then continue to include \acp{PE} in the lower end of the parent
+team's \ac{PE} range.
+If the triplet provided to \FUNC{shmem\_team\_split\_strided} implies such a
+wrap-around sequence, the input is considered invalid and the behavior is
+undefined.
 
 This routine must be called by all \acp{PE} in the parent team.
 All \acp{PE} must provide the same values for the \ac{PE} triplet.

--- a/content/shmem_team_split_strided.tex
+++ b/content/shmem_team_split_strided.tex
@@ -59,7 +59,7 @@ When $stride$ is less than zero, PEs in the new team are in \textit{reverse}
 relative order with respect to the parent team.
 If a $stride$ value equal to 0 is passed to \FUNC{shmem\_team\_split\_strided},
 then the $size$ argument passed must be 1, or the behavior is undefined.
-A newly created team must only include \acp{PE} whose subsequent parent \ac{PE}
+When $stride$ is nonzero, a newly created team must only include \acp{PE} whose subsequent parent \ac{PE}
 values are either all increasing (for positive $stride$) or all decreasing
 (for negative $stride$).
 That is, \textit{wrap-around} with respect to the parent team's \ac{PE} values

--- a/content/shmem_team_split_strided.tex
+++ b/content/shmem_team_split_strided.tex
@@ -59,17 +59,18 @@ When $stride$ is less than zero, PEs in the new team are in \textit{reverse}
 relative order with respect to the parent team.
 If a $stride$ value equal to 0 is passed to \FUNC{shmem\_team\_split\_strided},
 then the $size$ argument passed must be 1, or the behavior is undefined.
-When $stride$ is nonzero, a newly created team must only include \acp{PE} whose subsequent parent \ac{PE}
-values are either all increasing (for positive $stride$) or all decreasing
-(for negative $stride$).
+If the triplet provided to \FUNC{shmem\_team\_split\_strided} implies a
+wrap-around sequence, the input is considered invalid and the behavior is
+undefined.
+In other words, when $stride$ is nonzero, a newly created team must only
+include \acp{PE} whose subsequent parent \ac{PE} values are either all
+increasing (for positive $stride$) or all decreasing (for negative
+$stride$).
 That is, \textit{wrap-around} with respect to the parent team's \ac{PE} values
 is not permitted.
 For example, the list of \acp{PE} in the parent team should not start at a high
 number and then continue to include \acp{PE} in the lower end of the parent
 team's \ac{PE} range.
-If the triplet provided to \FUNC{shmem\_team\_split\_strided} implies such a
-wrap-around sequence, the input is considered invalid and the behavior is
-undefined.
 
 This routine must be called by all \acp{PE} in the parent team.
 All \acp{PE} must provide the same values for the \ac{PE} triplet.


### PR DESCRIPTION
# Summary of changes
This attempts to clarify that no team split "wrap-around" is allowed.

I found it a little tricky to specify, so please feel free to propose new or adjusted text.

I'm relying on #1 to account for the `start` argument description.

Changelog entry proposed here:
https://github.com/kwaters4/specification/pull/6/files